### PR TITLE
Remove npm cache clean call in Dockerfile.base

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -11,6 +11,6 @@ COPY package.json .
 # for a npm error saying: EXDEV: cross-device link not permitted
 ENV NODE_ENV=development
 
-RUN apk add --no-cache rsync curl ; npm set progress=false && npm install && npm cache clean
+RUN apk add --no-cache rsync curl ; npm set progress=false && npm install
 
 # NOTE: "node" user and corresponding "/home/node" dir are created by "node:6-alpine" image.


### PR DESCRIPTION
npm@5 emits a warning when using `cache clean` about the self-healing capabilities of the npm cache.
This removes the `cache clean` call.